### PR TITLE
Prevent quadradic behavior by using Sets to look up groups

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ function getCycles/*::<T>*/(currDepsMap /*: Graph<T> */, visited /*: Graph<T> */
 function graphSequencer/*::<T>*/(opts /*: Options<T> */) /*: Result<T> */ {
   let graph = opts.graph;
   let groups = opts.groups;
+  let groupsAsSets = groups.map(group => new Set(group));
   let graphItems = Array.from(graph.keys());
 
   // Ensure that we have the same set of items in both graph and groups.
@@ -108,12 +109,12 @@ function graphSequencer/*::<T>*/(opts /*: Options<T> */) /*: Result<T> */ {
       if (typeof deps === 'undefined') continue;
 
       // Find the index of the group that the `item` belongs to.
-      let itemGroup = groups.findIndex(group => group.includes(item));
+      let itemGroup = groupsAsSets.findIndex(group => group.has(item));
 
       // Filter down a set of deps which need to be run first.
       let currDeps = deps.filter(dep => {
         // Find the index of the group that the `dep` belongs to.
-        let depGroup = groups.findIndex(group => group.includes(dep));
+        let depGroup = groupsAsSets.findIndex(group => group.has(dep));
 
         if (depGroup > itemGroup) {
           return false;


### PR DESCRIPTION
I recently changed my WIP DT pnpm branch to include more things in devDeps, which made this code a bottleneck. Thankfully, we can do something similar to https://github.com/pnpm/pnpm/pull/6281 and avoid the quadradic lookup.

On DT, before this change:

![image](https://user-images.githubusercontent.com/5341706/231926471-a0ecf965-116a-4c65-82e7-a2ceed9c80d7.png)

After:

![image](https://user-images.githubusercontent.com/5341706/231926491-3717a372-3e99-4330-bfe7-9552f81eaffa.png)

There's probably still room for improvement here as there's still a linear search over every package (which is what groups are), but, this makes `graphSequencer` disappear which is good enough for me.